### PR TITLE
Add convenience feature: show % passed

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -122,9 +122,18 @@ fn run(tests: Vec<TestCase>, ctx: impl TestContext) -> i32 {
             Ok(()) => println!("OK"),
             Err(CompilationFail { message }) => println!("FAIL - Compilation failed:\n{message}"),
             Err(CompilationSuccess { name }) => println!("FAIL - Compilation mismatch, didn't expect '{name}' to compile"),
-            Err(ResultMismatch { input, output, expected }) => println!(
-                "FAIL - with input {input}\n    computed on GPU: {output}\n    computed on CPU: {expected}"
-            ),
+            Err(ResultMismatch {
+                input,
+                output,
+                expected,
+                total_cases,
+                passed_cases,
+            }) => {
+                let percent = (passed_cases as f32 / total_cases as f32) * 100f32;
+                println!(
+                    "FAIL - with input {input}\n    computed on GPU: {output}\n    computed on CPU: {expected}\n    passed: {passed_cases} out of {total_cases} ({percent}%)"
+                )
+            }
         }
     }
 


### PR DESCRIPTION
Displays the number of test cases that passed. Example:

```
cvt_rn_satfinite_e4m3x2_f32: FAIL - with input (
0b0000000000000000000000000000000000011010100000000000000000000001 0x1A800001 0.000000000000000000000053,
0b0000000000000000000000000000000000011010100000000000000000000001 0x1A800001 0.000000000000000000000053,
)
    computed on GPU: 0b0000000000000000000000000000000000000000000000000000000100000001 0x101 257
    computed on CPU: 0b0000000000000000000000000000000000000000000000000000000000000000 0x0 0
    passed: 4211081218 out of 4294967296 (98.046875%)
```

I think this is useful for gauging the conformance of an instruction.